### PR TITLE
fix hover of technologies section when switching between light/dark

### DIFF
--- a/src/components/Technologies.astro
+++ b/src/components/Technologies.astro
@@ -86,7 +86,7 @@ const items = [
       >
         {
           items.map(({ title, icon }) => (
-            <div class="relative flex flex-col p-3 bg-white dark:bg-slate-900 rounded shadow-xl hover:shadow-lg transition dark:border dark:border-slate-800">
+            <div class="relative flex flex-col p-3 bg-white dark:bg-slate-900 rounded shadow-xl hover:shadow-lg transition">
               <div class="flex items-center">
                 <Icon name={icon} class="w-12 h-12" />
                 <div class="ml-4 text-lg leading-5 font-bold">{title}</div>


### PR DESCRIPTION
border only exists on dark mode, so here is a vertical shift when switching between light and dark modes. 