### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/cypress/e2e/links-and-images.cy.ts
+++ b/cypress/e2e/links-and-images.cy.ts
@@ -1,3 +1,5 @@
+import * as urlLib from 'url';
+
 describe("links-and-images", () => {
   it("should return 200 for all links and images", () => {
     const testedPages = new Set<string>();
@@ -63,7 +65,10 @@ describe("links-and-images", () => {
               }
 
               cy.log('>>>> Adding "' + url + '" to pages to test');
-              if (url.includes("davidhu.io/") && !testedPages.has(url)) {
+              const parsedUrl = urlLib.parse(url);
+              const host = parsedUrl.host || "";
+              const allowedHosts = ["davidhu.io"];
+              if (allowedHosts.includes(host) && !testedPages.has(url)) {
                 pagesToTest.push(url);
               }
             });


### PR DESCRIPTION
Potential fix for [https://github.com/davidhu2000/davidhu2000.github.io/security/code-scanning/2](https://github.com/davidhu2000/davidhu2000.github.io/security/code-scanning/2)

To fix the problem, we need to parse the URL and check its host value against a whitelist of allowed hosts. This ensures that the check handles arbitrary subdomain sequences correctly and prevents bypassing the check by embedding the allowed host in an unexpected location.

1. Parse the URL using a URL parsing library.
2. Extract the host from the parsed URL.
3. Check if the host is in a whitelist of allowed hosts.
4. Update the code to use this method for URL validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
